### PR TITLE
Expand allow range for delayMicroseconds function

### DIFF
--- a/hardware/arduino/zunoG2/cores/LLCore/LLCore.c
+++ b/hardware/arduino/zunoG2/cores/LLCore/LLCore.c
@@ -665,7 +665,7 @@ dword micros(void){
 	return (dword)(rtcc_micros());
 }
 
-void delayMicroseconds(word tdelay){
+void delayMicroseconds(dword tdelay){
     while(tdelay--){
         asm("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
         asm("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");

--- a/hardware/arduino/zunoG2/cores/includes/Arduino.h
+++ b/hardware/arduino/zunoG2/cores/includes/Arduino.h
@@ -152,7 +152,7 @@ inline void zunoSetProductID(uint16_t product_id){
 void delay(dword ms);
 dword millis(void);
 dword micros(void);
-void delayMicroseconds(word tdelay);
+void delayMicroseconds(dword tdelay);
 inline void yield() { delay(1); }
 
 


### PR DESCRIPTION
As discussed in https://github.com/Z-Wave-Me/Z-Uno-G2-Core/issues/4.

This patch allows `delayMicroseconds` to accept a parameter larger than 65535.