### PR TITLE
Add REPORT_CHANNEL macro to ReportHandler.h

### DIFF
--- a/hardware/arduino/zunoG2/cores/ZWSupport/ReportHandler.h
+++ b/hardware/arduino/zunoG2/cores/ZWSupport/ReportHandler.h
@@ -44,6 +44,8 @@ float zunoReportFixToFloat(uint8_t len, uint8_t precision, uint8_t *array);
 
 #define REPORT_NODE_ID(report_data)							(((ReportAuxData_t *)report_data)->nodeIdSource)
 
+#define REPORT_CHANNEL(report_data)							(((ReportAuxData_t *)report_data)->channelSource)
+
 #define REPORT_BASIC_VALUE(report_data)						(((ZwBasicReportFrame_t *)((ReportAuxData_t *)report_data)->rawReportData)->v1.value)
 
 #define REPORT_SWITCH_BINARY_VALUE(report_data)				(((ZwBasicBinaryReportFrame_t *)((ReportAuxData_t *)report_data)->rawReportData)->v2.currentValue)


### PR DESCRIPTION
 I have three notification channels on a multi-channel device. Although I could use separate association groups to distinguish each notification source it's much easier to look at the source channel in the ReportHandler function. To do this I have added the macro:

#define REPORT_CHANNEL(report_data)		(((ReportAuxData_t *)report_data)->channelSource)

to ReportHandler.h in hardware/cores/ZWSupport.

See https://forum.z-wave.me/viewtopic.php?f=3427&t=35341