### PR TITLE
add ZUNO_SCD4x lib / example (CO2 sensor)

### DIFF
--- a/hardware/arduino/zunoG2/libraries/Z-Uno-2G/examples/SCD4x/ZUNO_SCD4x.ino
+++ b/hardware/arduino/zunoG2/libraries/Z-Uno-2G/examples/SCD4x/ZUNO_SCD4x.ino
@@ -103,8 +103,8 @@ void loop() {
 
       if (zunoLoadCFGParam(PARAM_FACTORY_RESET) == 1) 
       {
-        Serial.println("FACTORY RESET");
-        //SCD4x.perfomFactoryReset();
+        Serial.println("FACTORY RESET (inactive - see comment!");
+        //SCD4x.perfomFactoryReset();                // REMOVE COMMENT IF YOU WANT TO ENABLE FEATURE !
         zunoReboot();
       }
     }

--- a/hardware/arduino/zunoG2/libraries/Z-Uno-2G/examples/SCD4x/ZUNO_SCD4x.ino
+++ b/hardware/arduino/zunoG2/libraries/Z-Uno-2G/examples/SCD4x/ZUNO_SCD4x.ino
@@ -1,0 +1,150 @@
+#include "Wire.h"
+#include "ZUNO_SCD4x.h"
+uint16_t Address = 0x62;
+uint8_t cnt = 0;
+int16_t lastTemp = 0;
+int16_t curTemp;
+uint16_t curHum, curCO2;
+uint16_t lastHum = 0;
+uint16_t lastCO2 = 10;
+
+enum{
+    PARAM_TEMP_OFFSET=64,
+    PARAM_TEMP_HYST,
+    PARAM_HUMIDITY_HYST,
+    PARAM_CO2_HYST,
+    PARAM_REPORTING_INT,
+    PARAM_AMB_PRESSURE,
+    PARAM_SENS_ALT,
+    PARAM_FACTORY_RESET
+};
+
+ZUNO_SETUP_SLEEPING_MODE(ZUNO_SLEEPING_MODE_ALWAYS_AWAKE); //Z-Uno Sleaping mode
+ZUNO_SETUP_CHANNELS(
+  ZUNO_SENSOR_MULTILEVEL(ZUNO_SENSOR_MULTILEVEL_TYPE_CO2_LEVEL, SENSOR_MULTILEVEL_SCALE_PARTS_PER_MILLION, SENSOR_MULTILEVEL_SIZE_TWO_BYTES, SENSOR_MULTILEVEL_PRECISION_ZERO_DECIMALS, getterCO2),                                  
+  ZUNO_SENSOR_MULTILEVEL(ZUNO_SENSOR_MULTILEVEL_TYPE_TEMPERATURE, SENSOR_MULTILEVEL_SCALE_CELSIUS, SENSOR_MULTILEVEL_SIZE_TWO_BYTES, SENSOR_MULTILEVEL_PRECISION_ONE_DECIMAL, getterTemp),  
+  ZUNO_SENSOR_MULTILEVEL(ZUNO_SENSOR_MULTILEVEL_TYPE_RELATIVE_HUMIDITY, SENSOR_MULTILEVEL_SCALE_PERCENTAGE_VALUE, SENSOR_MULTILEVEL_SIZE_TWO_BYTES, SENSOR_MULTILEVEL_PRECISION_ONE_DECIMAL,getterHum)
+);
+ ZUNO_SETUP_CONFIGPARAMETERS(
+         ZUNO_CONFIG_PARAMETER_INFO("Temperature offset (step 1/10°C)", "Define temperature offset in 1/10 grad, it can depend on various factors such as the SCD4x measurement mode, self-heating of close components", 0, 200, 45),
+         ZUNO_CONFIG_PARAMETER_INFO("Temperature hysteresis (step 1/10°C)", "Defines hysteresis of temperature for additional sending value in 1/10 grad", 1, 20, 5),
+         ZUNO_CONFIG_PARAMETER_INFO("Humidity hysteresis", "Defines hysteresis of humidity for additional sending value", 1, 20, 5),
+         ZUNO_CONFIG_PARAMETER_INFO("CO2 hysteresis", "Defines hysteresis of CO2 value for additional sending value", 0, 1000, 0),
+         ZUNO_CONFIG_PARAMETER_INFO("Reporting interval (sec)", "Defines the default reporting interval (possible step: 5sec)", 20, 3600, 40),
+         ZUNO_CONFIG_PARAMETER_INFO("Ambient pressure (Pa)", "Note that setting an ambient pressure using 'Set Ambient Pressure' overrides any pressure compensation based on a previously set sensor altitude. Use of this command is highly recommended for applications *experiencing significant ambient pressure changes* to ensure sensor accuracy", 0, 150000, 0),
+         ZUNO_CONFIG_PARAMETER_INFO("Sensor altitude (m)", "Typically, the sensor altitude is set once after device installation", 0, 5000, 0),
+         ZUNO_CONFIG_PARAMETER_INFO("Factory reset", "Set to '1' for factory reset and then Z-Uno is restarting", 0, 1, 0)
+ );
+
+ZUNO_SCD4x SCD4x;
+
+void setup() {
+  float cfgParam1;
+  Wire.begin();  
+  Serial.begin(115200);
+  delay(1000);
+  SCD4x.stopPeriodicMeasurement();           // for reading/setting sensor parameters - see doc
+  
+  if(zunoInNetwork())
+  {
+    zunoSaveCFGParam(PARAM_FACTORY_RESET,0);   // Reset the value to default
+  
+    // Get configuration parameters and set sensor values (must be done before read measurement!)
+    cfgParam1 = zunoLoadCFGParam(PARAM_TEMP_OFFSET)/10.0;
+    bool result = SCD4x.setTemperatureOffset(cfgParam1);
+    cfgParam1 = zunoLoadCFGParam(PARAM_AMB_PRESSURE);
+    result = result && SCD4x.setAmbientPressure(cfgParam1);
+    cfgParam1 = zunoLoadCFGParam(PARAM_SENS_ALT);
+    result = result && SCD4x.setSensorAltitude(cfgParam1);
+    if (result == false) Serial.println("error while setting parameters! Error number: (" + String(SCD4x.comError) + ")");
+
+  }
+  else
+  {
+    Serial.println("Z-UNO IS NOT IN NETWORK INCLUDED - NO Z-WAVE FEATURES AVAILABLE!");
+  }
+  printSensorSettings();
+  bool ready = SCD4x.startPeriodicMeasurement();
+}
+
+void loop() {
+  delay(5000);  // minimum - see doc
+  SCD4x.readMeasurement();
+
+  if(zunoInNetwork())    // Check if Z-Uno is included in Network
+  {
+    cnt++;
+    if(zunoLoadCFGParam(PARAM_REPORTING_INT) <= cnt * 5) cnt = 0;   // define reporting interval
+  
+    // bool result = Serial.println(SCD4x.getDataReadyStatus()) ;  // optional use to be sure about it, integrated crc check will detect wrong values
+    if(SCD4x.comError == 0)
+    {
+      curCO2=SCD4x.CO2;
+      if(abs(lastCO2 - curCO2) >= zunoLoadCFGParam(PARAM_CO2_HYST) || cnt == 0)
+      {
+        zunoSendReport(1);
+        lastCO2 = curCO2;
+      }
+      Serial.print("CO2: ");Serial.println(curCO2);
+      curTemp=10*SCD4x.Temp;
+      if(abs(lastTemp - curTemp) >= 10 * zunoLoadCFGParam(PARAM_TEMP_HYST) || cnt == 0)
+      {
+        zunoSendReport(2);
+        lastTemp = curTemp;
+      }
+      Serial.print("Temp: ");Serial.println(curTemp/10.0);
+      curHum=10*SCD4x.Hum;
+      if(abs(lastHum - curHum) >= 10 * zunoLoadCFGParam(PARAM_HUMIDITY_HYST) || cnt == 0)
+      {
+        zunoSendReport(3);
+        lastHum = curHum;
+      }
+      Serial.print("Hum: ");Serial.println(curHum/10.0);
+
+      if (zunoLoadCFGParam(PARAM_FACTORY_RESET) == 1) 
+      {
+        Serial.println("FACTORY RESET");
+        //SCD4x.perfomFactoryReset();
+        zunoReboot();
+      }
+    }
+    else
+    {
+      Serial.print("communication error: "); Serial.println(SCD4x.comError);
+    }
+  }
+  else        // WITHOUT Z-WAVE NETWORK SIMPLE REQUEST  without error handling
+  {
+      Serial.println("-- NO Z-WAVE network! --");
+      Serial.print("CO2:  ");Serial.println(SCD4x.CO2);
+      Serial.print("Temp: ");Serial.println(SCD4x.Temp);
+      Serial.print("Hum:  ");Serial.println(SCD4x.Hum);
+  }
+}
+
+int getterCO2(void) {
+  return curCO2;
+}
+
+int getterTemp(void) {
+  return (curTemp);
+}
+
+int getterHum(void) {
+  return (curHum);
+}
+
+void printSensorSettings()
+{
+  bool result=SCD4x.getSensorData();
+  Serial.print("Sensor S/N: ");Serial.println(SCD4x.SerialNumber);
+  Serial.print("Temp.-Offset:");Serial.println(SCD4x.TempOffset);
+  Serial.print("Sensor Altitude: ");Serial.println(SCD4x.sensorAlt);
+  Serial.print("Sensor AutomaticSelfCalibration: ");Serial.println(SCD4x.sensorASC);
+  if(zunoInNetwork())
+  {
+    Serial.print("Sensor Ambient Pressure: ");Serial.println(zunoLoadCFGParam(PARAM_AMB_PRESSURE));
+    Serial.print("Sensor Factory Reset after reboot: ");Serial.println(zunoLoadCFGParam(PARAM_FACTORY_RESET));
+  }
+  if (result == false) Serial.println("error while getting sensor parameters!");
+}

--- a/hardware/arduino/zunoG2/libraries/ZUNO_SCD4x/ZUNO_SCD4x.cpp
+++ b/hardware/arduino/zunoG2/libraries/ZUNO_SCD4x/ZUNO_SCD4x.cpp
@@ -1,0 +1,335 @@
+/* CO2 sensor SCD4x library for Z-Uno G2
+ *  v. 1.0 07.09.2023  by Michael Pruefer
+ *  based on Sensirion sensor documentation
+ *  see https://sensirion.com/media/documents/E0F04247/631EF271/CD_DS_SCD40_SCD41_Datasheet_D1.pdf
+ *
+ */
+
+#include "Arduino.h"
+#include "ZUNO_SCD4x.h"
+#include "Wire.h"
+
+ZUNO_SCD4x::ZUNO_SCD4x()
+{
+}
+	
+bool ZUNO_SCD4x::startPeriodicMeasurement(void)
+{
+  if (sendCmd(SCD4x_CMD_STPM, 0)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::stopPeriodicMeasurement(void)
+{
+  if (sendCmd(SCD4x_CMD_SPPM, 500)) return (true);
+  return (false);
+}
+
+void ZUNO_SCD4x::readMeasurement(void)
+{
+  if (sendCmd(SCD4x_CMD_REAM, 1))
+  {
+    Wire.requestFrom(SCD4x_ADDR, 9);
+    byte data[2];
+    data[0] = Wire.read();
+    data[1] = Wire.read();
+    uint8_t crc = Wire.read();
+    uint8_t expectedCRC = calcCRC8(data, 2);
+    if(expectedCRC == crc) CO2=data[0]*256 + data[1]; else comError=2;
+
+    data[0] = Wire.read();
+    data[1] = Wire.read();
+    crc = Wire.read();
+    expectedCRC = calcCRC8(data, 2);
+    if(expectedCRC == crc) Temp=-45+175.0*(data[0]*256+data[1])/(65535); else comError=2;
+    data[0] = Wire.read();
+    data[1] = Wire.read();
+    crc = Wire.read();
+    expectedCRC = calcCRC8(data, 2);
+    if(expectedCRC == crc) Hum=100.0*(data[0]*256+data[1])/(65535); else comError=2;
+  }
+}
+
+bool ZUNO_SCD4x::getDataReadyStatus(void)
+{
+  uint16_t result = readDbyte(SCD4x_CMD_GDRA, 1);
+  if (comError != 0)  return (false);
+
+  //if least significant 11 bits are 0 → data not ready (docu)
+  if ((result & 0x07ff) == 0x0000) return (false);
+
+  return (true);
+}
+
+bool ZUNO_SCD4x::setTemperatureOffset(float tempOffset)
+{
+  uint16_t tOffset = tempOffset*65536/175;
+  if (sendCmd(SCD4x_CMD_STOF, tOffset, 1)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::getTemperatureOffset(void)
+{
+  uint16_t result = readDbyte(SCD4x_CMD_GTOF, 1);
+  if (comError != 0)  return (false);
+  TempOffset = ((float)result) * 175.0 / 65536;
+  return (true);
+}
+
+bool ZUNO_SCD4x::setSensorAltitude(uint16_t sensorAlt)
+{
+  if (sendCmd(SCD4x_CMD_SSAL, sensorAlt, 1)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::getSensorAltitude(void)
+{
+  uint16_t result = readDbyte(SCD4x_CMD_GSAL, 1);
+  if (comError != 0)  return (false);
+  sensorAlt=result;
+  return (true);
+}
+
+bool ZUNO_SCD4x::setAmbientPressure(uint32_t ambPressure)
+{
+  uint16_t sensorAmbPressure = ambPressure/100;
+  if (sendCmd(SCD4x_CMD_SAPR, sensorAmbPressure, 1)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::setAutomaticSelfCalibrationEnabled(uint16_t ASCEnabled)
+{
+  if (sendCmd(SCD4x_CMD_SACA, ASCEnabled, 1)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::getAutomaticSelfCalibrationEnabled(void)
+{
+  uint16_t result = readDbyte(SCD4x_CMD_GACA, 1);
+  if (comError != 0)  return (false);
+  sensorASC=result;
+  return (true);
+}
+
+bool ZUNO_SCD4x::perform_forced_recalibration(uint16_t targetCO2ppm)
+{
+  if (sendCmd(SCD4x_CMD_SACA, targetCO2ppm, 400)) 
+  {
+    byte data1[2];
+    Wire.requestFrom(SCD4x_ADDR,3);
+    data1[0] = Wire.read();
+    data1[1] = Wire.read();
+    crc = Wire.read();
+    uint8_t dataCRC = calcCRC8(data1, 2);
+    if (crc != dataCRC) 
+    {
+      comError=2;
+      return (false);
+    }  
+    uint16_t Correction = (uint16_t)data1[0] << 8 | data1[1]; 
+    if (CO2Correction == 0xFFFF) return (false);
+    CO2Correction = ((float)Correction) - 32768;  // see doc : result - 0x8000
+    return (true);
+  }
+  return (false);
+}
+
+bool ZUNO_SCD4x::startLowPowerPeriodicMeasurement(void)
+{
+  if (sendCmd(SCD4x_CMD_SLPM, 0)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::PersistSettings(void)
+{
+  if (sendCmd(SCD4x_CMD_PERS, 800)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::getSerialNumber(void)
+{
+  if (sendCmd(SCD4x_CMD_GSER, 1))
+  {
+    byte sn1[2];
+    byte sn2[2];
+    byte sn3[2];
+    uint8_t crc;
+    comError=0;
+    Wire.requestFrom(SCD4x_ADDR,9);
+    sn1[0] = Wire.read();
+    sn1[1] = Wire.read();
+    crc = Wire.read();
+    uint8_t dataCRC = calcCRC8(sn1, 2);
+    if (crc != dataCRC) comError=2;
+    sn2[0] = Wire.read();
+    sn2[1] = Wire.read();
+    crc = Wire.read();
+    dataCRC = calcCRC8(sn2, 2);
+    if (crc != dataCRC) comError=2;
+    sn3[0] = Wire.read();
+    sn3[1] = Wire.read();
+    crc = Wire.read();
+    dataCRC = calcCRC8(sn3, 2);
+    if (crc != dataCRC) comError=2;
+    if (comError ==0) 
+    {
+      char str[5];
+      arrayToString(sn1,2,str);
+      SerialNumber += str;
+      arrayToString(sn2,2,str);
+      SerialNumber += str;
+      arrayToString(sn3,2,str);
+      SerialNumber += str;
+      return (true);
+    }
+    else
+    { 
+      SerialNumber ="error";    
+    }  
+  }
+  return (false);
+}
+
+bool ZUNO_SCD4x::perfomFactoryReset(void)
+{
+  if (sendCmd(SCD4x_CMD_PFRS, 1200)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::reinit(void)
+{
+  if (sendCmd(SCD4x_CMD_PRIN, 20)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::measureSingleShot(void)
+{
+  if (sendCmd(SCD4x_CMD_MSSH, 5000)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::measureSingleShotRHTOnly(void)
+{
+  if (sendCmd(SCD4x_CMD_MSS1, 50)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::powerDown(void)
+{
+  if (sendCmd(SCD4x_CMD_PWDN, 1)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::wakeUp(void)
+{
+  if (sendCmd(SCD4x_CMD_WKUP, 1)) return (true);
+  return (false);
+}
+
+bool ZUNO_SCD4x::getSensorData(void)
+{
+  bool result=getSerialNumber();
+  result = result && getTemperatureOffset();
+  result = result && getSensorAltitude();
+  result = result && getAutomaticSelfCalibrationEnabled();
+  return (result);
+}  
+
+uint16_t ZUNO_SCD4x::readDbyte(uint16_t cmdCode, uint16_t delayMs)
+{
+  comError=0;
+  uint16_t result = 0xFFFF;
+  Wire.beginTransmission(SCD4x_ADDR);
+  Wire.write(cmdCode >> 8);   
+  Wire.write(cmdCode & 0xFF); 
+  if (Wire.endTransmission() != 0)
+  {
+    comError=1;                   //no ACK from SCD4x
+    return result;
+  }  
+  delay(delayMs);
+
+  Wire.requestFrom((uint8_t)SCD4x_ADDR, (uint8_t)3); // Request data and CRC
+  if (Wire.available())
+  {
+    uint8_t data[2];
+    data[0] = Wire.read();
+    data[1] = Wire.read();
+    uint8_t crc = Wire.read();
+    result = (uint16_t)data[0] << 8 | data[1];
+    uint8_t dataCRC = calcCRC8(data, 2);
+    if (crc != dataCRC) 
+      comError=2;
+  }
+  return (result);
+}
+
+bool ZUNO_SCD4x::sendCmd(uint16_t cmdCode, uint16_t delayMs)
+{
+  comError=0;
+  Wire.beginTransmission(SCD4x_ADDR);
+  Wire.write(cmdCode >> 8);   
+  Wire.write(cmdCode & 0xFF); 
+  if (Wire.endTransmission() != 0)
+  {
+    comError=1;                   //no ACK from SCD4x
+    return (false);
+  }  
+  delay(delayMs);
+
+  return (true);
+}
+
+bool ZUNO_SCD4x::sendCmd(uint16_t cmdCode, uint16_t parameter, uint16_t delayMs)
+{
+  comError=0;
+  uint8_t data[2];
+  data[0] = parameter >> 8;
+  data[1] = parameter & 0xFF;
+  uint8_t dataCRC = calcCRC8(data, 2);
+  Wire.beginTransmission(SCD4x_ADDR);
+  Wire.write(cmdCode >> 8);   
+  Wire.write(cmdCode & 0xFF); 
+  Wire.write(data[0]);   
+  Wire.write(data[1]); 
+  Wire.write(dataCRC); 
+  if (Wire.endTransmission() != 0)
+  {
+    comError=1;                   //no ACK from SCD4x
+    return (false);
+  }  
+  delay(delayMs);
+
+  return (true);
+}
+
+uint8_t ZUNO_SCD4x::calcCRC8(uint8_t data[], uint8_t len)
+// see Sensirion doc
+{
+  uint8_t crc = 0xFF; 
+
+  for (uint8_t i = 0; i < len; i++)
+  {
+    crc ^= data[i]; 
+    for (uint8_t bit = 8; bit > 0; --bit)
+    {
+      if ((crc & 0x80) != 0)
+        crc = (uint8_t)((crc << 1) ^ 0x31);
+      else
+        crc <<= 1;
+    }
+  }
+  return crc; 
+}
+
+void ZUNO_SCD4x::arrayToString(byte array[], uint8_t len, char strBuffer[])
+{
+    for (uint8_t i = 0; i < len; i++)
+    {
+      byte nib1 = (array[i] >> 4) & 0x0F;
+      byte nib2 = (array[i] >> 0) & 0x0F;
+      strBuffer[i*2+0] = nib1 < 10 ? '0' + nib1 : 'A' + nib1 - 10;
+      strBuffer[i*2+1] = nib2 < 10 ? '0' + nib2 : 'A' + nib2 - 10;
+    }
+    strBuffer[len*2] = '\0';
+}

--- a/hardware/arduino/zunoG2/libraries/ZUNO_SCD4x/ZUNO_SCD4x.h
+++ b/hardware/arduino/zunoG2/libraries/ZUNO_SCD4x/ZUNO_SCD4x.h
@@ -1,0 +1,89 @@
+/* CO2 sensor SCD4x library for Z-Uno G2
+ *  v. 1.0 07.09.2023  by Michael Pruefer
+ *  based on Sensirion sensor documentation
+ *  see https://sensirion.com/media/documents/E0F04247/631EF271/CD_DS_SCD40_SCD41_Datasheet_D1.pdf
+ *
+ */
+//ZUNO_SCD4x.h
+
+#ifndef ZUNO_SCD4x_h
+#define ZUNO_SCD4x_h
+
+#include "Arduino.h"
+
+#define SCD4x_ADDR  	0x62	// I2C Address
+
+#define SCD4x_CMD_STPM  0x21b1		// cmd start_periodic_measurement
+#define SCD4x_CMD_REAM  0xec05		// cmd read_measurement
+#define SCD4x_CMD_SPPM  0x3f86		// cmd stop_periodic_measurement
+#define SCD4x_CMD_STOF  0x241d		// cmd set_temperature_offset
+#define SCD4x_CMD_GTOF  0x2318		// cmd get_temperature_offset
+#define SCD4x_CMD_SSAL  0x2427		// cmd set_sensor_altitude
+#define SCD4x_CMD_GSAL  0x2322		// cmd get_sensor_altitude
+#define SCD4x_CMD_SAPR  0xe000		// cmd set_ambient_pressure
+#define SCD4x_CMD_PCAL  0x362f		// cmd perform_forced_recalibration
+#define SCD4x_CMD_SACA  0x2416		// cmd set_automatic_self_calibration_enabled
+#define SCD4x_CMD_GACA  0x2313		// cmd get_automatic_self_calibration_enabled
+#define SCD4x_CMD_SLPM  0x21ac		// cmd start_low_power_periodic_measurement
+#define SCD4x_CMD_GDRA  0xe4b8		// cmd get_data_ready_status
+#define SCD4x_CMD_PERS  0x3615		// cmd persist_settings
+#define SCD4x_CMD_GSER  0x3682		// cmd get_serial_number
+#define SCD4x_CMD_PSTE  0x3639		// cmd perform_self_test
+#define SCD4x_CMD_PFRS  0x3632		// cmd perfom_factory_reset
+#define SCD4x_CMD_PRIN  0x3646		// cmd reinit
+//SCD41
+#define SCD4x_CMD_MSSH  0x219d		// cmd measure_single_shot
+#define SCD4x_CMD_MSS1  0x2196		// cmd measure_single_shot_rht_only
+#define SCD4x_CMD_PWDN  0x36e0		// cmd power_down
+#define SCD4x_CMD_WKUP  0x36f6		// cmd wake_up
+
+
+class ZUNO_SCD4x
+{
+  public:
+	ZUNO_SCD4x();
+	bool startPeriodicMeasurement(void);
+	bool stopPeriodicMeasurement(void);
+	void readMeasurement(byte*,int);    // read data
+	void readMeasurement(void);    // read data
+  bool getDataReadyStatus(void);
+  bool setTemperatureOffset(float tempOffset);
+  bool getTemperatureOffset(void);
+  bool setSensorAltitude(uint16_t sensorAlt);
+  bool getSensorAltitude(void);
+  bool setAmbientPressure(uint32_t ambPressure);
+  bool setAutomaticSelfCalibrationEnabled(uint16_t ASCEnabled);
+  bool getAutomaticSelfCalibrationEnabled(void);
+  bool perform_forced_recalibration(uint16_t targetCO2ppm);
+  bool startLowPowerPeriodicMeasurement(void);
+  bool PersistSettings(void);
+  bool getSerialNumber(void);
+  bool perfomFactoryReset(void);
+  bool reinit(void);
+  bool measureSingleShot(void);
+  bool measureSingleShotRHTOnly(void);
+  bool powerDown(void);
+  bool wakeUp(void);
+  bool getSensorData(void);           // read all sensor properties
+
+	// sensor properties
+  uint16_t CO2;
+	float Temp;
+	float Hum;
+  float TempOffset;
+  uint8_t comError;               // 1- I2C error, 2- CRC error
+  uint16_t sensorASC;
+  uint16_t sensorAlt;
+  float CO2Correction;
+  String SerialNumber;
+
+  private:
+	uint16_t crc;
+  bool sendCmd(uint16_t cmdCode, uint16_t delayMs);
+  bool sendCmd(uint16_t cmdCode, uint16_t parameter, uint16_t delayMs);
+  uint16_t readDbyte(uint16_t registerAddress, uint16_t delayMs = 1);
+  uint8_t calcCRC8(uint8_t data[], uint8_t len);
+  void arrayToString(byte array[], uint8_t len, char strBuffer[]);
+};
+
+#endif


### PR DESCRIPTION
Created a lib for Z-Uno 2 for CO2 sensor SCD40/41

Added a Z-Wave example code for the sensor, tested with latest Z-Uno Beta (3.12) and Z-Way 4.1.1

You can add it into your distribution for free of use if you like.