### PR TITLE
Fix issue mentioned here: https://forum.z-wave.me/viewtopic.php?t=35673

### DIFF
--- a/hardware/arduino/zunoG2/libraries/ZUNO_DS18B20/ZUNO_DS18B20.cpp
+++ b/hardware/arduino/zunoG2/libraries/ZUNO_DS18B20/ZUNO_DS18B20.cpp
@@ -82,7 +82,8 @@ int DS18B20Sensor::getTempC100(byte * addr)
 	size_t				current_resolution;
 
 	byte dallas_data[9];
-	int temp = BAD_TEMP;
+	int16_t temp = BAD_TEMP;
+	int32_t tempC100 = BAD_TEMP;
 	byte i;
 
 	if (!my_ow->reset())
@@ -149,11 +150,10 @@ int DS18B20Sensor::getTempC100(byte * addr)
     // temp /= 0.16 
     // will be
     // 16/100 => 4/25 => temp *= 25; tem/=4;
-    temp *= 25;
-    temp >>= 2;
+    tempC100 = (int32_t)temp * 25;
+    tempC100 >>= 2;
     
-
-    return temp;
+    return tempC100;
 }
 
 float DS18B20Sensor::getTemperature(byte * addr) {


### PR DESCRIPTION
On Zuno 2, when DS18B20 returns negative temperature values, the scaled temperature returned by getTempC100 is wrong.

Maybe this code broke when switching from the 16-bit platform in Zuno 1 to the 32-bit platform in Zuno 2?  On the 32-bit Zuno 2 platform, the method used to store the 16-bit temperature data in the 32-bit signed int won't sign-extend negative values.  So, it appears as a large positive value.

This fix uses platform independent types to first store the 16-bit temperature data to a signed 16-bit integer, then scale to 32-bit scaled temperature.  It should work on either platform, but I can only test it on a Zuno 2.  Also, I think the fixed point arithmetic always needed to occur in a 32-bit value (so there was probably a bug in Zuno 1 with high temperatures).  Consider that the DS18B20 can return a maximum absolute value temperature of 125C, which is represented as positive 2000 decimal.  When multiplied first by 25, the value would become 50000, which overflows a signed 16-bit integer.  The final max scaled value would be 12500, which does fit into a 16-bit integer.  So, casting the 32-bit integer back to a 16-bit integer on the Zuno 1 platform is OK.